### PR TITLE
opencollab-scvs-meta: Add new CSV export format

### DIFF
--- a/scripts/opencollab-scsv-meta
+++ b/scripts/opencollab-scsv-meta
@@ -16,84 +16,85 @@ from opencollab.wiki import WikiFailure
 from opencollab.util.config import parseOptions
 
 
-def to_rows(pages, multivalue, separator):
-    if multivalue == "duplicate-keys":  # Default sorting (Legacy)
-        counts = {}
-        for page, metas in pages.iteritems():
-            for key, values in metas.iteritems():
-                counts[key] = max(counts.get(key, 0), len(values))
-        keys = sorted(counts.keys())
+def to_rows_default(pages):
+    counts = {}
+    for page, metas in pages.iteritems():
+        for key, values in metas.iteritems():
+            counts[key] = max(counts.get(key, 0), len(values))
+    keys = sorted(counts.keys())
 
-        keyrow = ["Page name"]
+    keyrow = ["Page name"]
+    for key in keys:
+        keyrow.extend([key] * counts[key])
+    yield keyrow
+
+    for page in sorted(pages):
+        metas = pages[page]
+        row = [encode(page)]
         for key in keys:
-            keyrow.extend([key] * counts[key])
-        yield keyrow
+            values = sorted(metas.get(key, []))
+            row.extend(map(encode, values))
+            row.extend([""] * (counts[key] - len(values)))
+        yield row
 
-        for page in sorted(pages):
-            metas = pages[page]
+
+def page_keys(pages):
+    keys = set()
+    for page, metas in pages.iteritems():
+        for key, values in metas.iteritems():
+            keys.add(key)
+    return keys
+
+
+def keyrow(keys):
+    keys = sorted(keys)
+    keyrow = ["Page name"]
+    keyrow.extend(keys)
+    return keyrow
+
+
+def to_rows_aggregate(pages, separator):
+    keys = page_keys(pages)
+    yield keyrow(keys)
+
+    for page in sorted(pages):
+        metas = pages[page]
+        row = [encode(page)]
+        for key in keys:
+            if key in metas:
+                values = metas[key]
+                stringified = encode(separator.join(values))
+                row.extend([stringified])
+            else:
+                row.extend([""])
+        yield row
+
+
+def to_rows_multi_row(pages):
+    keys = page_keys(pages)
+    yield keyrow(keys)
+
+    for page in sorted(pages):
+        metas = pages[page]
+
+        while True:
+            content = False
             row = [encode(page)]
-            for key in keys:
-                values = sorted(metas.get(key, []))
-                row.extend(map(encode, values))
-                row.extend([""] * (counts[key] - len(values)))
-            yield row
 
-    if multivalue == "aggregate-values":
-        keys = set()
-        for page, metas in pages.iteritems():
-            for key, values in metas.iteritems():
-                keys.add(key)
-
-        keys = sorted(keys)
-        keyrow = ["Page name"]
-        keyrow.extend(keys)
-        yield keyrow
-
-        for page in sorted(pages):
-            metas = pages[page]
-            row = [encode(page)]
             for key in keys:
                 if key in metas:
-                    values = metas[key]
-                    stringified = encode(separator.join(values))
-                    row.extend([stringified])
+                    values = list(metas[key])
+                    if len(values) > 0:
+                        row.extend([encode(values.pop())])
+                        content = True
+                    metas[key] = values
                 else:
                     row.extend([""])
-            yield row
 
-    if multivalue == "multi-row":
-        keys = set()
-        for page, metas in pages.iteritems():
-            for key, values in metas.iteritems():
-                keys.add(key)
-
-        keys = sorted(keys)
-        keyrow = ["Page name"]
-        keyrow.extend(keys)
-        yield keyrow
-
-        for page in sorted(pages):
-            metas = pages[page]
-
-            while True:
-                content = False
-                row = [encode(page)]
-
-                for key in keys:
-                    if key in metas:
-                        values = list(metas[key])
-                        if len(values) > 0:
-                            row.extend([encode(values.pop())])
-                            content = True
-                        metas[key] = values
-                    else:
-                        row.extend([""])
-
-                if content:
-                    yield row
-                else:
-                    break
-
+            if content:
+                yield row
+            else:
+                break
 
 
 def encode(x):
@@ -146,14 +147,19 @@ while True:
     try:
         collab = CLIWiki(ssl_verify_cert=x509, ssl_ca_certs=x509_ca_file, **ops['creds'])
 
-        print(repr(ops[sect]))
-
         if "get" in ops[sect]:
             query = ops[sect]["get"]
             if query:
                 results = collab.getMeta(query)
                 writer = csv.writer(sys.stdout, delimiter=";")
-                writer.writerows(to_rows(results, ops[sect]["multivalues"], ops[sect]["multivalue_separator"]))
+
+                if ops[sect]["multivalues"] == "duplicate-keys":
+                    writer.writerows(to_rows_default(results))
+                if ops[sect]["multivalues"] == "aggregate-values":
+                    writer.writerows(to_rows_aggregate(results, ops[sect]["multivalue_separator"]))
+                if ops[sect]["multivalues"] == "multi-row":
+                    writer.writerows(to_rows_multi_row(results))
+
                 sys.stdout.flush()
 
         if "set" in ops[sect]:

--- a/scripts/opencollab-scsv-meta
+++ b/scripts/opencollab-scsv-meta
@@ -16,26 +16,84 @@ from opencollab.wiki import WikiFailure
 from opencollab.util.config import parseOptions
 
 
-def to_rows(pages):
-    counts = {}
-    for page, metas in pages.iteritems():
-        for key, values in metas.iteritems():
-            counts[key] = max(counts.get(key, 0), len(values))
-    keys = sorted(counts.keys())
+def to_rows(pages, multivalue, separator):
+    if multivalue == "duplicate-keys":  # Default sorting (Legacy)
+        counts = {}
+        for page, metas in pages.iteritems():
+            for key, values in metas.iteritems():
+                counts[key] = max(counts.get(key, 0), len(values))
+        keys = sorted(counts.keys())
 
-    keyrow = ["Page name"]
-    for key in keys:
-        keyrow.extend([key] * counts[key])
-    yield keyrow
-
-    for page in sorted(pages):
-        metas = pages[page]
-        row = [encode(page)]
+        keyrow = ["Page name"]
         for key in keys:
-            values = sorted(metas.get(key, []))
-            row.extend(map(encode, values))
-            row.extend([""] * (counts[key] - len(values)))
-        yield row
+            keyrow.extend([key] * counts[key])
+        yield keyrow
+
+        for page in sorted(pages):
+            metas = pages[page]
+            row = [encode(page)]
+            for key in keys:
+                values = sorted(metas.get(key, []))
+                row.extend(map(encode, values))
+                row.extend([""] * (counts[key] - len(values)))
+            yield row
+
+    if multivalue == "aggregate-values":
+        keys = set()
+        for page, metas in pages.iteritems():
+            for key, values in metas.iteritems():
+                keys.add(key)
+
+        keys = sorted(keys)
+        keyrow = ["Page name"]
+        keyrow.extend(keys)
+        yield keyrow
+
+        for page in sorted(pages):
+            metas = pages[page]
+            row = [encode(page)]
+            for key in keys:
+                if key in metas:
+                    values = metas[key]
+                    stringified = encode(separator.join(values))
+                    row.extend([stringified])
+                else:
+                    row.extend([""])
+            yield row
+
+    if multivalue == "multi-row":
+        keys = set()
+        for page, metas in pages.iteritems():
+            for key, values in metas.iteritems():
+                keys.add(key)
+
+        keys = sorted(keys)
+        keyrow = ["Page name"]
+        keyrow.extend(keys)
+        yield keyrow
+
+        for page in sorted(pages):
+            metas = pages[page]
+
+            while True:
+                content = False
+                row = [encode(page)]
+
+                for key in keys:
+                    if key in metas:
+                        values = list(metas[key])
+                        if len(values) > 0:
+                            row.extend([encode(values.pop())])
+                            content = True
+                        metas[key] = values
+                    else:
+                        row.extend([""])
+
+                if content:
+                    yield row
+                else:
+                    break
+
 
 
 def encode(x):
@@ -49,29 +107,34 @@ def decode(x):
 def escape(x):
     return x.encode("unicode-escape")
 
-operations = list()
-
-
-def callback(option, opt, value, parser, operation):
-    operations.append((operation, value))
 
 usage = "usage: %prog [options]"
 parser = OptionParser(usage=usage)
 
-parser.add_option("-G", "--get", action="callback",
-                  callback=callback, callback_args=("get",), type="string",
+parser.add_option("-G", "--get", type="string",
                   help=("Get metadata from Wiki with a  MetaTable argument " +
                         "string."))
-parser.add_option("-A", "--add", action="callback",
-                  callback=callback, callback_args=("add",), type="string",
+parser.add_option("-A", "--add", type="string",
                   help=("Add metadata based on a semicolon-delimited CSV file " +
                         "in a batch fashion. First row states the keys, " +
                         "first colums states the pages."))
-parser.add_option("-S", "--set", action="callback",
-                  callback=callback, callback_args=("set",), type="string",
+parser.add_option("-S", "--set", type="string",
                   help=("Replace metadata based on a semicolon-delimited CSV " +
                         "file in a batch fashion. First row states the keys, " +
                         "first colums states the pages."))
+parser.add_option("--multivalues",
+                  type="choice",
+                  choices=["duplicate-keys", "aggregate-values", "multi-row"],
+                  default="duplicate-keys",
+                  help=("How to handle keys with multiple values:\n" +
+                        "duplicate-keys: default, keys with multiple values get " +
+                        "duplicate keys in the header for each instance of value.\n" +
+                        "aggregate-keys: combine multivalues into a list for each row"
+                        "multi-row: split multivalued keys into multiple rows, "
+                        "by writing subsequent multivalues on each row until all"
+                        "the values have been output"))
+parser.add_option("--multivalue-separator", type="string", default="|",
+                  help="Separator for multivalued data (aggregate-values)")
 
 sect = "csv-meta"
 ops = parseOptions(parser, sect, config=True, template=True)
@@ -81,41 +144,46 @@ template = ops[sect]["template"]
 
 while True:
     try:
-        collab = CLIWiki(ssl_verify_cert=x509, ssl_ca_certs=x509_ca_file, 
-                         **ops['creds'])
+        collab = CLIWiki(ssl_verify_cert=x509, ssl_ca_certs=x509_ca_file, **ops['creds'])
+
+        print(repr(ops[sect]))
+
+        if "get" in ops[sect]:
+            query = ops[sect]["get"]
+            if query:
+                results = collab.getMeta(query)
+                writer = csv.writer(sys.stdout, delimiter=";")
+                writer.writerows(to_rows(results, ops[sect]["multivalues"], ops[sect]["multivalue_separator"]))
+                sys.stdout.flush()
+
+        if "set" in ops[sect]:
+            filename = ops[sect]["set"]
+            if filename:
+                reader = csv.reader(open(filename, "rb"), delimiter=";")
+
+                # Keys from first row, ignore the key for the first column
+                keys = []
+                for keys in reader:
+                    keys = keys[1:]
+                    break
+
+                for row in reader:
+                    if not row:
+                        continue
+
+                    page = decode(row[0])
+
+                    metas = dict()
+                    for key, value in zip(keys, row[1:]):
+                        metas.setdefault(key, []).append(value)
+
+                    result = collab.setMeta(page, metas, True, template)
+                    for line in result:
+                        print >> sys.stderr, escape(page) + ":", escape(line)
+
     except WikiFailure:
         print "ERROR: Authentication failed."
     except (UnicodeError, socket.gaierror):
         sys.exit("ERROR: Not a valid URL.")
     else:
         break
-
-for operation, argument in operations:
-    if operation == "get":
-        results = collab.getMeta(argument)
-        writer = csv.writer(sys.stdout, delimiter=";")
-        writer.writerows(to_rows(results))
-        sys.stdout.flush()
-    else:
-        replace = operation == "set"
-        reader = csv.reader(open(argument, "rb"), delimiter=";")
-
-        # Keys from first row, ignore the key for the first column
-        keys = []
-        for keys in reader:
-            keys = keys[1:]
-            break
-
-        for row in reader:
-            if not row:
-                continue
-
-            page = decode(row[0])
-
-            metas = dict()
-            for key, value in zip(keys, row[1:]):
-                metas.setdefault(key, []).append(value)
-
-            result = collab.setMeta(page, metas, replace, template)
-            for line in result:
-                print >> sys.stderr, escape(page) + ":", escape(line)


### PR DESCRIPTION
When collab pages have multivalued keys, the default export format creates a duplicate key for each separate value. 

The old way is represented with the default flag:

--multivalues=duplicate-keys [default]

Example: 

Page name;key1;key1;key2;key3;key3;key3;key4;key4
meta1;value1;value2;value3;value4;value5;value6;;
meta2;;;value3,7;value4;value5;value6;value1;value2
metatest;;;;;;;;

There have been requests to handle the export in a way that preserves the number of columns as long as no new keys are added. I've added two alternative methods to achieve this, with flags

--multivalues=multi-row

Example:

Page name;key1;key2;key3;key4
meta1;value1;value3;value4;
meta1;value2;;value5;
meta1;;;value6;
meta2;;value3,7;value4;value1
meta2;;;value5;value2
meta2;;;value6;

Another way to do this is the more traditional "use a second separator for multivalues" approach, also implemented:

--multivalues=aggregate-values

Example:

Page name;key1;key2;key3;key4
meta1;value2|value1;value3;value6|value5|value4;
meta2;;value3,7;value6|value5|value4;value2|value1
metatest;;;;

There are some questions:
1. Do we want to support this second method
2. Which one of the implementations is preferred, or should we include both
